### PR TITLE
De-dup the list of deps only after the local dep has been added.

### DIFF
--- a/src/Keiretsu/Config.hs
+++ b/src/Keiretsu/Config.hs
@@ -31,7 +31,7 @@ import           System.Directory
 import           System.FilePath
 
 loadDeps :: FilePath -> IO [Dep]
-loadDeps rel = nub <$> loadDeps' Set.empty rel
+loadDeps rel = loadDeps' Set.empty rel
   where
     loadDeps' memo rel' = do
         dir <- canonicalizePath rel'

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -19,6 +19,7 @@ module Main
 import           Control.Applicative
 import           Control.Monad
 import qualified Data.ByteString.Char8 as BS
+import           Data.List (nub)
 import           Data.Monoid
 import           Keiretsu.Config
 import           Keiretsu.Log
@@ -58,7 +59,7 @@ main = runCommand $ \opts@Start{..} _ -> do
     setLogging sDebug
 
     d  <- makeLocalDep
-    ds <- reverse . (d :) <$> loadDeps sDir
+    ds <- reverse . nub . (d :) <$> loadDeps sDir
 
     ps <- readProcs ds
 


### PR DESCRIPTION
This ensures that the project being started does not indirectly depend on itself and is thus started twice, which can happen right now if a transitive dependency leads back to the project under test.
