### PR TITLE
Better error message when failing to create the syslog socket

### DIFF
--- a/src/Keiretsu/Config.hs
+++ b/src/Keiretsu/Config.hs
@@ -31,7 +31,7 @@ import           System.Directory
 import           System.FilePath
 
 loadDeps :: FilePath -> IO [Dep]
-loadDeps rel = loadDeps' Set.empty rel
+loadDeps = loadDeps' Set.empty
   where
     loadDeps' memo rel' = do
         dir <- canonicalizePath rel'


### PR DESCRIPTION
If for some reason keiretsu fails to create the syslog socket, it will fail with a `bind` error, which will send you on a wild-goose chase with netstat and lsof. This PR makes it fail with a better error message.
