### PR TITLE
Support for allocating multiple ports to a proctype

### DIFF
--- a/keiretsu.cabal
+++ b/keiretsu.cabal
@@ -36,8 +36,8 @@ executable keiretsu
 
     build-depends:
           async
-        , attoparsec
         , ansi-terminal        >= 0.6
+        , attoparsec
         , base                 >  4.6 && < 5
         , bytestring
         , containers
@@ -45,7 +45,7 @@ executable keiretsu
         , filepath
         , hslogger
         , io-streams
-        , optparse-applicative == 0.9.*
         , network
+        , optparse-applicative == 0.9.*
         , process              >= 1.2
         , unix

--- a/src/Keiretsu/Config.hs
+++ b/src/Keiretsu/Config.hs
@@ -64,7 +64,7 @@ readEnvs ds fs ps = do
   where
     read' path = logDebug ("Reading " ++ path ++ " ...") >> readFile path
 
-    merge env = nubBy ((==) `on` fst) . (++ env) . concatMap procPorts
+    merge env = nubBy ((==) `on` fst) . (++ env) . concatMap remotePortEnv
     parse     = map (second tail . break (== '=')) . lines . concat
 
 readProcs :: Int -> [Dep] -> IO [Proc]

--- a/src/Keiretsu/Config.hs
+++ b/src/Keiretsu/Config.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 -- Module      : Keiretsu.Config
 -- Copyright   : (c) 2013 Brendan Hay <brendan.g.hay@gmail.com>
 -- License     : This Source Code Form is subject to the terms of
@@ -16,14 +18,14 @@ module Keiretsu.Config
 
 import           Control.Applicative
 import           Control.Arrow
-import           Control.Exception     (bracket)
+import           Control.Exception                (bracket)
 import           Control.Monad
-import qualified Data.Attoparsec       as P
-import qualified Data.Attoparsec.Char8 as P8
-import qualified Data.ByteString.Char8 as BS
+import qualified Data.Attoparsec.ByteString       as P
+import qualified Data.Attoparsec.ByteString.Char8 as P8
+import qualified Data.ByteString.Char8            as BS
 import           Data.Function
 import           Data.List
-import qualified Data.Set as Set
+import qualified Data.Set                         as Set
 import           Keiretsu.Log
 import           Keiretsu.Types
 import           Network.Socket
@@ -62,24 +64,22 @@ readEnvs ds fs ps = do
   where
     read' path = logDebug ("Reading " ++ path ++ " ...") >> readFile path
 
-    merge env = nubBy ((==) `on` fst) . (++ env) . map procPort
+    merge env = nubBy ((==) `on` fst) . (++ env) . concatMap procPorts
     parse     = map (second tail . break (== '=')) . lines . concat
 
-readProcs :: [Dep] -> IO [Proc]
-readProcs = liftM concat . mapM readProcfile
+readProcs :: Int -> [Dep] -> IO [Proc]
+readProcs p = liftM concat . mapM readProcfile
   where
     readProcfile d = do
         let cfg = joinPath [depPath d, "Procfile"]
         logDebug $ "Reading " ++ cfg ++ " ..."
         xs <- readConfig (makeProc d) cfg
-        ys <- freePorts $ length xs
+        ys <- freePorts (length xs)
         return $! zipWith ($) xs ys
 
     freePorts n = do
-        ss <- sequence . take n $ repeat assignSocket
-        ps <- mapM ((fromIntegral <$>) . socketPort) ss
-        mapM_ close ss
-        return ps
+        !ss <- replicateM n . sequence $ replicate p assignSocket
+        forM ss . mapM $ \s -> fromIntegral <$> socketPort s <* close s
 
     assignSocket = do
         s <- socket AF_INET Stream defaultProtocol

--- a/src/Keiretsu/Types.hs
+++ b/src/Keiretsu/Types.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns    #-}
 
 -- Module      : Keiretsu.Types
 -- Copyright   : (c) 2013 Brendan Hay <brendan.g.hay@gmail.com>

--- a/src/Keiretsu/Types.hs
+++ b/src/Keiretsu/Types.hs
@@ -53,11 +53,10 @@ makeLocalProc name cmd = do
 
 portVars :: String -> String -> Int -> Word16 -> (String, String)
 portVars x y n (show -> p)
-    | n == 0    = (fmt name, p)
-    | otherwise = (fmt $ name ++ [show n], p)
+    | n == 0    = (name, p)
+    | otherwise = (name ++ show n, p)
   where
-    fmt  = map toUpper . intercalate "_"
-    name = [x, y, "PORT"]
+    name = map toUpper . intercalate "_" $ [x, y, "PORT"]
 
 data Cmd = Cmd
     { cmdPre   :: !String

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -101,18 +101,17 @@ main = do
 
     d  <- makeLocalDep
     ds <- reverse . nub . (d :) <$> loadDeps sDir
-
     ps <- readProcs sPorts ds
-
     pe <- readEnvs ds sEnvs ps
     le <- getEnvironment
-
-    ex <- mapM (makeLocalProc "run") sRuns
+    pr <- mapM (makeLocalProc "run") sRuns
 
     let delay = sDelay * 1000
         disc  = makeCmds pe delay ps
-        spec  = makeCmds (pe ++ le) delay ex
+        spec  = makeCmds (pe ++ le) delay pr
         cmds  = filter ((`notElem` sExclude) . cmdPre) $ disc ++ spec
+
+    print disc
 
     when sDebug $ dumpEnv cmds
     unless sDryRun $ runCommands cmds


### PR DESCRIPTION
Adds a new option `--ports/-p` which can be used to control the number of contiguous ports assigned to each individual `proctype`. The default is 2 ports.

Fixes #10 
